### PR TITLE
Provide linux zip package

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
       ],
       "target": [
         "deb",
-        "rpm"
+        "rpm",
+        "zip"
       ]
     },
     "win": {


### PR DESCRIPTION
In order to build an Archlinux version, it's much more easier if you can get gulp to build a zip version for linux (a .tar.gz version would be great too!) 
