### PR TITLE
Add snap support and package ndm

### DIFF
--- a/lib/js/npm/npm-api.js
+++ b/lib/js/npm/npm-api.js
@@ -218,7 +218,7 @@ angular.module(moduleName, [])
       let globalFolder = stdout
         , nodeModulesExt = ''; //important
 
-      if (process.platform != 'win32') {
+      if (process.platform !== 'win32') {
 
         globalFolder = globalFolder.replace('/lib/node_modules', '');
       } else {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
       "target": [
         "deb",
         "rpm",
-        "zip"
+        "zip",
+        "snap"
       ]
     },
     "win": {
@@ -133,7 +134,7 @@
     "babel-preset-es2015-rollup": "^3.0.0",
     "del": "^2.2.0",
     "electron": "^1.6.6",
-    "electron-builder": "^17.3.1",
+    "electron-builder": "^19.53.0",
     "eslint": "^3.13.1",
     "gulp": "^3.9.1",
     "gulp-clean-css": "^2.2.0",


### PR DESCRIPTION
I've_ put together this pull request to add a snap package. I've tested it on Ubuntu 16.04, but it should work just as well on Ubuntu 14.04, Linux Mint, Manjaro, Debian, OpenSUSE, Solus, etc.

If you merge and `npm run build-linux` on an Ubuntu 16.04 VM with an appropriate version of node installed it will create releases/ndm_1.2.0_amd64.snap.

Copy this to a Linux system, enable snap support, then run: `sudo snap install ndm_1.2.0_amd64.snap --dangerous`. Execute it with `ndm` from the terminal or find it in the desktop launcher.

If you create a developer account and push this to the Snap Store, it can be discovered and installed through GNOME Software and https://snapcraft.io/discover. To create the developer account, sign up here, then register the "ndm" name.

You'll need the snapcraft command to push the snap file to the store.

If you're on a Mac, you can brew install snapcraft
If you're on Linux, it's sudo snap install --classic snapcraft
Then you can push it to the store out with: `snapcraft push ndm_1.2.0_amd64.snap --release stable`