### PR TITLE
Fix outdated RPM repo URL (README.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ On RedHat based linux is possible to install **ndm** doing:
 ```bash
 echo "[fury]               
 name=ndm repository
-baseurl=https://repo.fury.io/720kb/
+baseurl=https://yum.fury.io/720kb/
 enabled=1
 gpgcheck=0" | sudo tee /etc/yum.repos.d/ndm.repo && sudo yum update && sudo yum install ndm
 ```


### PR DESCRIPTION
Looks like RPM repo URL is outdated.

"Warning: failed to load '/etc/yum.repos.d/ndm.repo', ignoring."

See [https://gemfury.com/720kb/rpm:ndm](https://gemfury.com/720kb/rpm:ndm)

