### PR TITLE
Fix lint error: replace != with !==

### DIFF
--- a/lib/js/npm/npm-api.js
+++ b/lib/js/npm/npm-api.js
@@ -218,7 +218,7 @@ angular.module(moduleName, [])
       let globalFolder = stdout
         , nodeModulesExt = ''; //important
 
-      if (process.platform != 'win32') {
+      if (process.platform !== 'win32') {
 
         globalFolder = globalFolder.replace('/lib/node_modules', '');
       } else {


### PR DESCRIPTION
```
[14:33:37] Using gulpfile ~/build/720kb/ndm/gulpfile.js
[14:33:37] Starting 'lint'...
[14:33:40] 'lint' errored after 2.55 s
[14:33:40] ESLintError in plugin 'gulp-eslint'
Message:
    Expected '!==' and instead saw '!='.
```